### PR TITLE
add: some options to farmers script; fix: rubocop to SymbolArray brac…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,7 @@ Style/FrozenStringLiteralComment:
 
 Metrics/BlockLength:
   IgnoredMethods: ['describe', 'context', 'feature', 'scenario', 'let']
+
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: brackets

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 5.0'
 
 group :development, :test do
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry'
   gem 'rspec-rails'
 end
@@ -36,4 +36,4 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ Opções disponíveis:
 
 add_scripts: adiciona a pasta de scripts ao PATH com o alias 'farmers'
 bash: abre um terminal bash
+bin-setup: executa bin/setup
+bundle <args>: executa o comando passado com bundle exec dentro do container
 console: rails console
+db:migrate: executa db:migrate
+db:prepare: executa db:prepare
 rubocop: executa o rubocop
 rubycritic: executa o rubycritic e guarda os relatórios em reports/
-rspec: executa o rspec
+run <args>: executa o comando passado dentro do container web
+rspec <args>: executa o rspec
 setup: refaz imagem e bd
 start: inicia os containeres
 stop: para os containeres

--- a/scripts/farmers
+++ b/scripts/farmers
@@ -20,8 +20,20 @@ case "$command_name" in
   bash)
     run_in_container bash
     ;;
+  bin-setup)
+    run_in_container bundle exec bin/setup
+    ;;
+  bundle)
+    run_in_container bundle exec ${@:2}
+    ;;
   console)
     run_in_container bundle exec rails console
+    ;;
+  db:migrate)
+    run_in_container bundle exec rails db:migrate
+    ;;
+  db:prepare)
+    run_in_container bundle exec rails db:prepare
     ;;
   rubocop)
     run_in_container rubocop ${@:2}
@@ -30,13 +42,15 @@ case "$command_name" in
     mkdir -p -- "$rubycritic_dir"
     run_in_container rubycritic -p $rubycritic_dir
     ;;
+  run)
+    run_in_container ${@:2}
+    ;;
   rspec)
     run_in_container bundle exec rspec ${@:2}
     ;;
   setup)
     docker-compose build --no-cache
     run_in_container bundle exec bin/setup
-    docker-compose rm -f -s
     ;;
   start)
     docker-compose up
@@ -52,10 +66,15 @@ case "$command_name" in
     echo
     echo "add_scripts: adiciona a pasta de scripts ao PATH com o alias 'farmers'"
     echo "bash: abre um terminal bash"
+    echo "bin-setup: executa bin/setup"
+    echo "bundle <args>: executa o comando passado com bundle exec dentro do container"
     echo "console: rails console"
+    echo "db:migrate: executa db:migrate"
+    echo "db:prepare: executa db:prepare"
     echo "rubocop: executa o rubocop"
     echo "rubycritic: executa o rubycritic e guarda os relatórios em reports/"
-    echo "rspec: executa o rspec"
+    echo "run <args>: executa o comando passado dentro do container web"
+    echo "rspec <args>: executa o rspec"
     echo "setup: refaz imagem e bd"
     echo "start: inicia os containeres"
     echo "stop: para os containeres"


### PR DESCRIPTION
Adiciona as seguintes opções ao farmers:
- bin/setup
- db:migrate
- db:prepare
- run

Adiciona ao rubocop a configuração para validar array de symbols como válidos sem o uso de literals.
Ex:
good = [:symbol1, :symbol2]
bad = %i[symbol1 symbol2]

Close #18 