### PR TITLE
fix: db creation on compose-up using entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,11 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /farmers_app/tmp/pids/server.pid
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+bundle exec rails db:prepare
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"

--- a/scripts/farmers
+++ b/scripts/farmers
@@ -53,7 +53,6 @@ case "$command_name" in
     run_in_container bundle exec bin/setup
     ;;
   start)
-    run_in_container bundle exec rails db:prepare
     docker-compose up
     ;;
   stop)


### PR DESCRIPTION
Adiciona o comando `rails db:prepare` ao arquivo entrypoint.sh para criar os databases quando os containeres forem refeitos.

Close #61 